### PR TITLE
add pod type int

### DIFF
--- a/include/rohrkabel/spa/pod/pod.hpp
+++ b/include/rohrkabel/spa/pod/pod.hpp
@@ -20,6 +20,7 @@ namespace pipewire::spa
         string    = 8,
         boolean   = 2,
         object    = 15,
+        num_int   = 4,
         num_float = 6,
         array     = 13,
     };
@@ -99,6 +100,8 @@ namespace pipewire::spa
     template <>
     bool pod::as() const;
     template <>
+    int pod::as() const;
+    template <>
     float pod::as() const;
     template <>
     pod_object pod::as() const;
@@ -107,6 +110,8 @@ namespace pipewire::spa
 
     template <>
     void pod::write(const bool &);
+    template <>
+    void pod::write(const int &);
     template <>
     void pod::write(const float &);
 } // namespace pipewire::spa

--- a/src/spa/spa.pod.cpp
+++ b/src/spa/spa.pod.cpp
@@ -129,6 +129,13 @@ namespace pipewire::spa
     }
 
     template <>
+    int pod::as() const
+    {
+        assert(type() == spa::type::num_int);
+        return reinterpret_cast<spa_pod_int *>(m_impl->pod.get())->value;
+    }
+
+    template <>
     float pod::as() const
     {
         assert(type() == spa::type::num_float);
@@ -154,6 +161,13 @@ namespace pipewire::spa
     {
         assert(type() == spa::type::boolean);
         reinterpret_cast<spa_pod_bool *>(m_impl->pod.get())->value = value;
+    }
+
+    template <>
+    void pod::write(const int &value)
+    {
+        assert(type() == spa::type::num_int);
+        reinterpret_cast<spa_pod_int *>(m_impl->pod.get())->value = value;
     }
 
     template <>


### PR DESCRIPTION
So far only few of the base types specified in spa are mapped in this library. Adding type int is crucial for e.g. brightness property in video inputs.